### PR TITLE
Fixed the sequence of dom and cleaned up css

### DIFF
--- a/themes/awi-revamped/js/carousel-fixes.js
+++ b/themes/awi-revamped/js/carousel-fixes.js
@@ -1,48 +1,46 @@
-/* js/carousel-fixes.js */
 (function ($) {
   'use strict';
-
-  // All trip carousels on the page
-  var SLIDERS = '.trip_highlight_items, .hotels_slider, .trip_options_slider';
 
   // Hide dots when there's only one "page" of slides
   function toggleDots(slick) {
     if (!slick || !slick.$dots) return;
 
-    // If Slick provides dot count, use it; fallback to slide math
-    var pages = (typeof slick.getDotCount === 'function') ? slick.getDotCount() : null;
-    var showDots;
+    var pages = (typeof slick.getDotCount === 'function')
+      ? slick.getDotCount()
+      : Math.ceil(slick.slideCount / (slick.options.slidesToShow || 1));
 
-    if (pages !== null) {
-      // Slick returns 0 when there is only one page
-      showDots = pages > 0;
-    } else {
-      var visible = slick.options.slidesToShow || 1;
-      showDots = slick.slideCount > visible;
-    }
-    $(slick.$dots).toggle(!!showDots);
+    var showDots = pages > 1; // only show if more than one page
+    $(slick.$dots).toggle(showDots);
   }
 
-  // Keep dots state correct on all lifecycle events
-  $(document).on('init reInit setPosition afterChange breakpoint', SLIDERS, function (e, slick) {
+  // Which sliders we care about
+  var sliderTargets = '.trip_highlight_items, .hotels_slider, .trip_options_slider, .js-carousel .slick-slider';
+
+  // Keep dots state correct on init / resize / slide changes
+  $(document).on('init reInit setPosition afterChange breakpoint', sliderTargets, function (e, slick) {
     toggleDots(slick);
   });
 
-   // === INITIATE Slick on trip highlights ===
+  // Initialize Slick sliders
   $(function () {
-    $('.trip_highlight_items').slick({
-      slidesToShow: 3,
-      slidesToScroll: 1,
-      arrows: true,
-      dots: true,
-      adaptiveHeight: true,      // smoother first render
-      lazyLoad: 'progressive',   // images load smoothly
-      prevArrow: '<button type="button" class="slick-prev" aria-label="Previous"><i class="fa-solid fa-angle-left"></i></button>',
-      nextArrow: '<button type="button" class="slick-next" aria-label="Next"><i class="fa-solid fa-angle-right"></i></button>',
-      responsive: [
-        { breakpoint: 1023, settings: { slidesToShow: 2 } },
-        { breakpoint: 767,  settings: { slidesToShow: 1 } }
-      ]
+    $('.trip_highlight_items, .hotels_slider, .trip_options_slider').each(function () {
+      var $el = $(this);
+      if (!$el.hasClass('slick-initialized')) {
+        $el.slick($.extend(true, {
+          slidesToShow: 3,
+          slidesToScroll: 1,
+          arrows: true,
+          dots: true,
+          adaptiveHeight: true,
+          lazyLoad: 'progressive',
+          prevArrow: '<button type="button" class="slick-prev" aria-label="Previous"><i class="fa-solid fa-angle-left" aria-hidden="true"></i></button>',
+          nextArrow: '<button type="button" class="slick-next" aria-label="Next"><i class="fa-solid fa-angle-right" aria-hidden="true"></i></button>',
+          responsive: [
+            { breakpoint: 1023, settings: { slidesToShow: 2 } },
+            { breakpoint: 767,  settings: { slidesToShow: 1 } }
+          ]
+        }, $el.data('slick') || {}));
+      }
     });
   });
 

--- a/themes/awi-revamped/style.css
+++ b/themes/awi-revamped/style.css
@@ -4026,19 +4026,41 @@ nav{
   }
 }
 
-
 /* --------------------------------------------------------------
    CAROUSEL FIXES — Chevron arrows with responsive outer spacing
+   Targets: .trip_highlight_items, .hotels_slider, .trip_options_slider
    -------------------------------------------------------------- */
 
-/* Reset UL defaults */
+/* Group helper */
 .trip_highlight_items,
 .hotels_slider,
-.trip_options_slider {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+.trip_options_slider { list-style: none; margin: 0; padding: 0; }
+
+/* Prevent FOUC while Slick bootstraps */
+.trip_highlight_items,
+.hotels_slider,
+.trip_options_slider { opacity: 0; transition: opacity .25s ease; }
+
+/* Show only after Slick initializes */
+.trip_highlight_items.slick-initialized,
+.hotels_slider.slick-initialized,
+.trip_options_slider.slick-initialized { opacity: 1; }
+
+/* Hide controls until initialized */
+.trip_highlight_items .slick-arrow,
+.trip_highlight_items .slick-dots,
+.hotels_slider .slick-arrow,
+.hotels_slider .slick-dots,
+.trip_options_slider .slick-arrow,
+.trip_options_slider .slick-dots { display: none !important; }
+
+.trip_highlight_items.slick-initialized .slick-arrow,
+.hotels_slider.slick-initialized .slick-arrow,
+.trip_options_slider.slick-initialized .slick-arrow { display: flex !important; }
+
+.trip_highlight_items.slick-initialized .slick-dots,
+.hotels_slider.slick-initialized .slick-dots,
+.trip_options_slider.slick-initialized .slick-dots { display: block !important; }
 
 /* Arrow containers */
 .trip_highlight_items .slick-prev,
@@ -4062,31 +4084,24 @@ nav{
   justify-content: center;
 }
 
-/* --------------------------------------------------------------
-   Padding between cards and arrows — desktop default
-   -------------------------------------------------------------- */
+/* Desktop default outer padding */
 .trip_highlight_items .slick-prev,
 .hotels_slider .slick-prev,
-.trip_options_slider .slick-prev {
-  left: -36px !important;
-}
+.trip_options_slider .slick-prev { left: -36px !important; }
+
 .trip_highlight_items .slick-next,
 .hotels_slider .slick-next,
-.trip_options_slider .slick-next {
-  right: -36px !important;
-}
+.trip_options_slider .slick-next { right: -36px !important; }
 
-/* Kill Slick’s pseudo icons */
+/* Remove Slick’s pseudo-icons */
 .trip_highlight_items .slick-prev:before,
 .trip_highlight_items .slick-next:before,
 .hotels_slider .slick-prev:before,
 .hotels_slider .slick-next:before,
 .trip_options_slider .slick-prev:before,
-.trip_options_slider .slick-next:before {
-  content: none !important;
-}
+.trip_options_slider .slick-next:before { content: none !important; }
 
-/* Chevron icons */
+/* Chevron icon look */
 .trip_highlight_items .slick-prev i,
 .trip_highlight_items .slick-next i,
 .hotels_slider .slick-prev i,
@@ -4094,128 +4109,76 @@ nav{
 .trip_options_slider .slick-prev i,
 .trip_options_slider .slick-next i {
   font-size: 28px;
-  color: rgba(0, 0, 0, 0.55);
-  transition: color 0.2s ease;
+  color: rgba(0,0,0,.55);
+  transition: color .2s ease;
 }
 .trip_highlight_items .slick-prev:hover i,
 .trip_highlight_items .slick-next:hover i,
 .hotels_slider .slick-prev:hover i,
 .hotels_slider .slick-next:hover i,
 .trip_options_slider .slick-prev:hover i,
-.trip_options_slider .slick-next:hover i {
-  color: rgba(0, 0, 0, 0.85);
-}
+.trip_options_slider .slick-next:hover i { color: rgba(0,0,0,.85); }
+
+/* Dots spacing (JS will hide if only one page) */
+.trip_highlight_items .slick-dots,
+.hotels_slider .slick-dots,
+.trip_options_slider .slick-dots { margin-top: 14px; text-align: center; }
 
 /* --------------------------------------------------------------
    RESPONSIVE SPACING
    -------------------------------------------------------------- */
 
-/* Laptop to tablet (1024px and below) */
+/* ≤1024px */
 @media (max-width: 1024px) {
   .trip_highlight_items .slick-prev,
   .hotels_slider .slick-prev,
-  .trip_options_slider .slick-prev {
-    left: -28px !important;
-  }
+  .trip_options_slider .slick-prev { left: -28px !important; }
+
   .trip_highlight_items .slick-next,
   .hotels_slider .slick-next,
-  .trip_options_slider .slick-next {
-    right: -28px !important;
-  }
+  .trip_options_slider .slick-next { right: -28px !important; }
 }
 
-/* Tablet (768px and below) */
+/* ≤768px */
 @media (max-width: 768px) {
   .trip_highlight_items .slick-prev,
   .trip_highlight_items .slick-next,
   .hotels_slider .slick-prev,
   .hotels_slider .slick-next,
   .trip_options_slider .slick-prev,
-  .trip_options_slider .slick-next {
-    width: 40px;
-    height: 40px;
-  }
+  .trip_options_slider .slick-next { width: 40px; height: 40px; }
 
   .trip_highlight_items .slick-prev,
   .hotels_slider .slick-prev,
-  .trip_options_slider .slick-prev {
-    left: -22px !important;
-  }
+  .trip_options_slider .slick-prev { left: -22px !important; }
+
   .trip_highlight_items .slick-next,
   .hotels_slider .slick-next,
-  .trip_options_slider .slick-next {
-    right: -22px !important;
-  }
+  .trip_options_slider .slick-next { right: -22px !important; }
 }
 
-/* Mobile (480px and below) */
+/* ≤480px */
 @media (max-width: 480px) {
   .trip_highlight_items .slick-prev,
   .trip_highlight_items .slick-next,
   .hotels_slider .slick-prev,
   .hotels_slider .slick-next,
   .trip_options_slider .slick-prev,
-  .trip_options_slider .slick-next {
-    width: 34px;
-    height: 34px;
-  }
+  .trip_options_slider .slick-next { width: 34px; height: 34px; }
 
   .trip_highlight_items .slick-prev,
   .hotels_slider .slick-prev,
-  .trip_options_slider .slick-prev {
-    left: -16px !important;
-  }
+  .trip_options_slider .slick-prev { left: -16px !important; }
+
   .trip_highlight_items .slick-next,
   .hotels_slider .slick-next,
-  .trip_options_slider .slick-next {
-    right: -16px !important;
-  }
+  .trip_options_slider .slick-next { right: -16px !important; }
 }
 
-/* Dots styling */
-.trip_highlight_items .slick-dots,
-.hotels_slider .slick-dots,
-.trip_options_slider .slick-dots {
-  margin-top: 14px;
-  text-align: center;
-}
-
-/* Prevent FOUC while Slick bootstraps */
-.trip_highlight_items,
-.hotels_slider,
-.trip_options_slider {
-  opacity: 0;                 /* hide before init */
-  transition: opacity .2s ease;
-}
-
-/* Show only after Slick initializes */
-.trip_highlight_items.slick-initialized,
-.hotels_slider.slick-initialized,
-.trip_options_slider.slick-initialized {
-  opacity: 1;
-}
-
-/* Hide controls until initialized */
-.trip_highlight_items .slick-arrow,
-.trip_highlight_items .slick-dots,
-.hotels_slider .slick-arrow,
-.hotels_slider .slick-dots,
-.trip_options_slider .slick-arrow,
-.trip_options_slider .slick-dots {
-  display: none !important;
-}
-.trip_highlight_items.slick-initialized .slick-arrow,
-.hotels_slider.slick-initialized .slick-arrow,
-.trip_options_slider.slick-initialized .slick-arrow { display: flex !important; }
-.trip_highlight_items.slick-initialized .slick-dots,
-.hotels_slider.slick-initialized .slick-dots,
-.trip_options_slider.slick-initialized .slick-dots { display: block !important; }
-
-/* (Optional) make sure slide images don’t jump during load */
+/* Images shouldn’t jump during load */
 .trip_highlight_items img,
 .hotels_slider img,
-.trip_options_slider img {
-  display: block;
-  width: 100%;
-  height: auto;
-}
+.trip_options_slider img { display: block; width: 100%; height: auto; }
+
+/* Hide single slick dot if it ever renders */
+.slick-dots li:first-child:last-child { display: none; }


### PR DESCRIPTION
removes duplicate opacity rules (use only the slick-initialized fade-in)

keeps arrows/dots hidden until initialized

groups repeated selectors

keeps your responsive offsets

leaves the optional “hide single dot” safeguard